### PR TITLE
Improve hardware info detection and error handling

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -119,7 +119,7 @@ class Main extends Sprite {
 		// me on my way to perfectly position this fucking debug display so it doesnt piss me off:
 		ramCount = new DebugDisplay(6, 13, 0xffffff);
 		addChild(ramCount);
-		toggleMEM(#if mobile true #else false #end);
+		toggleMEM(true);
 
 		ramPie = new DebugPie(1080, 3, 0xffffff);
 		addChild(ramPie);

--- a/source/stats/DebugDisplay.hx
+++ b/source/stats/DebugDisplay.hx
@@ -17,6 +17,8 @@ class DebugDisplay extends TextField {
 	public var showFlixel:Bool = false;
 	public var showSystem:Bool = false;
 	public var forceUpdate:Bool = false;
+	
+	var metaInitialized:Bool = false;
 
 	// sys
 	private var platform:String = '???';
@@ -37,11 +39,14 @@ class DebugDisplay extends TextField {
 
 		width = 440;
 		height = 290;
-
-		resetMeta();
 	}
 
 	private function resetMeta() {
+		if (metaInitialized)
+			return;
+
+		metaInitialized = true;
+
 		platform = '${LimeSys.platformLabel} ${LimeSys.platformVersion}';
 
 		#if windows
@@ -87,6 +92,9 @@ class DebugDisplay extends TextField {
 	private override function __enterFrame(deltaTime:Float):Void {
 		if (!visible)
 			return; // why would we calculate this if its not visible.
+
+		if (showSystem && !metaInitialized)
+			resetMeta();
 
 		if (!forceUpdate) {
 			lastFT += deltaTime;

--- a/source/stats/DebugDisplay.hx
+++ b/source/stats/DebugDisplay.hx
@@ -43,14 +43,42 @@ class DebugDisplay extends TextField {
 
 	private function resetMeta() {
 		platform = '${LimeSys.platformLabel} ${LimeSys.platformVersion}';
+
 		#if windows
-		var process = new Process('wmic', ['cpu', 'get', 'name']);
-		if (process.exitCode() == 0) {
-			cpu = process.stdout.readAll().toString().trim().split('\n')[1].trim();
-			cpu += ' ${Capabilities.cpuArchitecture} ${Capabilities.supports64BitProcesses ? '64 Bit' : '32 Bit'}';
+		try {
+			var process = new Process(
+				'powershell',
+				[
+					'-NoProfile',
+					'-Command',
+					'Get-CimInstance Win32_Processor | Select-Object -ExpandProperty Name'
+				]
+			);
+
+			if (process.exitCode() == 0) {
+				cpu = process.stdout.readAll().toString().trim();
+				cpu += ' ${Capabilities.cpuArchitecture} ${Capabilities.supports64BitProcesses ? "64 Bit" : "32 Bit"}';
+			}
+		} catch (e:Dynamic) {
+			cpu = 'Unknown CPU';
 		}
 		#end
-		@:privateAccess gpu = Std.string(FlxG.stage.context3D.gl.getParameter(FlxG.stage.context3D.gl.RENDERER)).split("/")[0];
+
+		try {
+			@:privateAccess
+			if (FlxG.stage != null && FlxG.stage.context3D != null) {
+				gpu = Std.string(
+					FlxG.stage.context3D.gl.getParameter(
+						FlxG.stage.context3D.gl.RENDERER
+					)
+				).split("/")[0];
+			} else {
+				gpu = "Unknown GPU";
+			}
+		} catch (e:Dynamic) {
+			gpu = "Unknown GPU";
+		}
+
 		engVer = Main.denpaEngineVersion.debugVersion;
 	}
 


### PR DESCRIPTION
Updated CPU detection on Windows to use PowerShell for better reliability and added error handling for both CPU and GPU info retrieval. Also simplified toggleMEM usage in Main.hx to always enable memory display.

Fixes #13 